### PR TITLE
FIX: Skip unexported fields

### DIFF
--- a/pkg/internal/lang/go/parse.go
+++ b/pkg/internal/lang/go/parse.go
@@ -157,6 +157,11 @@ func parseFile(ctx context.Context, filename string) ([]generator.Stmt, error) {
 		// columns
 		if r.StructType != nil {
 			for _, field := range r.StructType.Fields.List {
+				// skip not exported fields
+				if field.Names == nil || !field.Names[0].IsExported() {
+					continue
+				}
+
 				column := &generator.CreateTableColumn{}
 
 				tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`"))


### PR DESCRIPTION
<!-- markdownlint-disable MD004 MD041 -->

## Ticket / Issue Number

<img width="909" alt="Screenshot 2025-02-27 at 7 51 25 PM" src="https://github.com/user-attachments/assets/8bfec466-5892-48db-ab2a-7e020387dcb8" />

I'm using ddlctl to generate sql schema for structs generated by protobuf's protoc that included some private (unexported) fields.

## What's changed

Just add condition to **skip** unexported fields

## Remark

> [!NOTE]
> *Please provide additional remarks if necessary.*

<!-- markdownlint-enable MD004 MD041 -->

<!--
- [x] _
-->
